### PR TITLE
Error Fixes as per YenPoints Feedback

### DIFF
--- a/bsv/__init__.py
+++ b/bsv/__init__.py
@@ -20,4 +20,4 @@ from .encrypted_message import *
 from .signed_message import *
 
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'

--- a/bsv/chaintrackers/whatsonchain.py
+++ b/bsv/chaintrackers/whatsonchain.py
@@ -25,7 +25,7 @@ class WhatsOnChainTracker(ChainTracker):
             f"{self.URL}/block/{height}/header", request_options
         )
         if response.ok:
-            merkleroot = response.json()["data"]["merkleroot"]
+            merkleroot = response.json()['data'].get("merkleroot")
             return merkleroot == root
         elif response.status_code == 404:
             return False
@@ -35,9 +35,7 @@ class WhatsOnChainTracker(ChainTracker):
             )
 
     def get_headers(self) -> Dict[str, str]:
-        headers = {
-            "Accept": "application/json",
-        }
+        headers = {}
         if self.api_key:
             headers["Authorization"] = self.api_key
         return headers

--- a/bsv/transaction_input.py
+++ b/bsv/transaction_input.py
@@ -27,7 +27,10 @@ class TransactionInput:
         if source_transaction:
             utxo = source_transaction.outputs[source_output_index]
 
-        self.source_txid: str = source_txid if source_txid else '00' * 32
+        self.source_txid = source_txid
+        if source_transaction and not source_txid:
+            self.source_txid = source_transaction.txid()
+
         self.source_output_index: int = source_output_index
         self.satoshis: int = utxo.satoshis if utxo else None
         self.locking_script: Script = utxo.locking_script if utxo else None

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,3 +1,5 @@
+import pytest 
+
 from bsv.constants import SIGHASH
 from bsv.hash import hash256
 from bsv.keys import PrivateKey
@@ -642,5 +644,29 @@ def test_ef_serialization():
     expected_ef = "010000000000000000ef01478a4ac0c8e4dae42db983bc720d95ed2099dec4c8c3f2d9eedfbeb74e18cdbb1b0100006b483045022100b05368f9855a28f21d3cb6f3e278752d3c5202f1de927862bbaaf5ef7d67adc50220728d4671cd4c34b1fa28d15d5cd2712b68166ea885522baa35c0b9e399fe9ed74121030d4ad284751daf629af387b1af30e02cf5794139c4e05836b43b1ca376624f7fffffffff10000000000000001976a9140c77a935b45abdcf3e472606d3bc647c5cc0efee88ac01000000000000000070006a0963657274696861736822314c6d763150594d70387339594a556e374d3948565473446b64626155386b514e4a406164386337373536356335363935353261626463636634646362353537376164633936633866613933623332663630373865353664666232326265623766353600000000"
     assert ef.hex() == expected_ef
 
+
+def test_input_auto_txid():
+    prev_tx = Transaction.from_hex('0100000001478a4ac0c8e4dae42db983bc720d95ed2099dec4c8c3f2d9eedfbeb74e18cdbb1b0100006b483045022100b05368f9855a28f21d3cb6f3e278752d3c5202f1de927862bbaaf5ef7d67adc50220728d4671cd4c34b1fa28d15d5cd2712b68166ea885522baa35c0b9e399fe9ed74121030d4ad284751daf629af387b1af30e02cf5794139c4e05836b43b1ca376624f7fffffffff01000000000000000070006a0963657274696861736822314c6d763150594d70387339594a556e374d3948565473446b64626155386b514e4a406164386337373536356335363935353261626463636634646362353537376164633936633866613933623332663630373865353664666232326265623766353600000000')
+    
+    private_key = PrivateKey("L5agPjZKceSTkhqZF2dmFptT5LFrbr6ZGPvP7u4A6dvhTrr71WZ9")
+
+    tx_in = TransactionInput(
+        source_transaction=prev_tx,
+        source_output_index=0,
+        unlocking_script_template=P2PKH().unlock(private_key),
+    )
+    
+    assert tx_in.source_txid == 'e6adcaf6b86fb5d690a3bade36011cd02f80dd364f1ecf2bb04902aa1b6bf455'
+    
+    prev_tx.outputs[0].locking_script = None
+    with pytest.raises(Exception):
+        unsigned_to_varint(-1)
+    
+        tx_in = TransactionInput(
+            source_transaction=prev_tx,
+            source_output_index=0,
+            unlocking_script_template=P2PKH().unlock(private_key),
+        )
+    
 
 # TODO: Test tx.verify()

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -660,13 +660,11 @@ def test_input_auto_txid():
     
     prev_tx.outputs[0].locking_script = None
     with pytest.raises(Exception):
-        unsigned_to_varint(-1)
-    
         tx_in = TransactionInput(
             source_transaction=prev_tx,
             source_output_index=0,
             unlocking_script_template=P2PKH().unlock(private_key),
         )
-    
+
 
 # TODO: Test tx.verify()


### PR DESCRIPTION
Fixes for:

- LIBP-88 - Fixed WoC Tracker. Wrong request header casued it to fail.
- LIBP-90 - If `source_txid` is omitted in the constructor of `TransactionInput`, it is automatically derived from `source_transaction`.
