### PR TITLE
Add: ScriptChunk in __init__.py

### DIFF
--- a/bsv/script/__init__.py
+++ b/bsv/script/__init__.py
@@ -1,4 +1,4 @@
-from .script import Script
+from .script import Script, ScriptChunk
 from .type import ScriptTemplate, Unknown, P2PKH, OpReturn, P2PK, BareMultisig, to_unlock_script_template
 from .spend import Spend
 from .unlocking_template import UnlockingScriptTemplate


### PR DESCRIPTION
## Description of Changes

The issue with importing ScriptChunk from bsv.script was caused by the __init__.py file in the /bsv/script directory not including ScriptChunk in its export definitions. To resolve this issue, the following changes were made:

Updated the __init__.py file in the /bsv/script directory to explicitly include ScriptChunk in its import and export definitions.
Ensured consistency with the expected behavior, so from bsv import ScriptChunk works as intended.

## Linked Issues / Tickets

Closes #11.

## Testing Procedure

Without error:

$ python
Python 3.11.9 (main, Apr 19 2024, 16:48:06) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from bsv import ScriptChunk
>>> 

