### PR TITLE
[Fix] Remove debug print statement from MerklePath.trim() method and unnece…

### DIFF
--- a/bsv/merkle_path.py
+++ b/bsv/merkle_path.py
@@ -1,4 +1,3 @@
-# from .chain_tracker import ChainTracker
 from typing import List, Optional, TypedDict
 
 from .chaintracker import ChainTracker
@@ -333,7 +332,7 @@ class MerklePath:
                     push_if_new(peer["offset"], drop_offsets)
 
         drop_offsets_from_level(drop_offsets, 0)
-        print('testing', self.path)
+        # print('testing', self.path)
         for h in range(1, len(self.path)):
             drop_offsets = computed_offsets
             computed_offsets = next_computed_offsets(computed_offsets)


### PR DESCRIPTION
## Description of Changes

Remove debug print statement from MerklePath.trim() method and unnecessary import statement

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x ] All tests pass locally
- [ x] I have tested manually in my local environment

## Checklist:

- x[ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I have run the linter