### PR TITLE
[Changed]: Enable regular hex format broadcasting when source transactions are unavailable

### DIFF
--- a/bsv/broadcasters/arc.py
+++ b/bsv/broadcasters/arc.py
@@ -59,14 +59,18 @@ class ARC(Broadcaster):
             self.headers = config.headers
 
     async def broadcast(
-        self, tx: 'Transaction'
+            self, tx: 'Transaction'
     ) -> Union[BroadcastResponse, BroadcastFailure]:
+        # Check if all inputs have source_transaction
+        has_all_source_txs = all(input.source_transaction is not None for input in tx.inputs)
         request_options = {
             "method": "POST",
             "headers": self.request_headers(),
-            "data": {"rawTx": tx.to_ef().hex()},
+            "data": {
+                "rawTx":
+                    tx.to_ef().hex() if has_all_source_txs else tx.hex()
+            }
         }
-
         try:
             response = await self.http_client.fetch(
                 f"{self.URL}/v1/tx", request_options

--- a/tests/test_arc_ef_or_rawhex.py
+++ b/tests/test_arc_ef_or_rawhex.py
@@ -1,0 +1,109 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from typing import Union, List
+
+
+# テスト対象のクラスとメソッドをモックで再現
+class Transaction:
+    def __init__(self, inputs=None):
+        self.inputs = inputs or []
+
+    def to_ef(self):
+        # EFフォーマットに変換するメソッドをモック
+        mock = MagicMock()
+        mock.hex.return_value = "ef_formatted_hex_data"
+        return mock
+
+    def hex(self):
+        return "normal_hex_data"
+
+
+class Input:
+    def __init__(self, source_transaction=None):
+        self.source_transaction = source_transaction
+
+
+class BroadcastResponse:
+    pass
+
+
+class BroadcastFailure:
+    pass
+
+
+class TransactionBroadcaster:
+    def request_headers(self):
+        return {"Content-Type": "application/json"}
+
+    async def broadcast(self, tx: 'Transaction') -> Union[BroadcastResponse, BroadcastFailure]:
+        # Check if all inputs have source_transaction
+        has_all_source_txs = all(input.source_transaction is not None for input in tx.inputs)
+        request_options = {
+            "method": "POST",
+            "headers": self.request_headers(),
+            "data": {
+                "rawTx": tx.to_ef().hex() if has_all_source_txs else tx.hex()
+            }
+        }
+        return request_options  # テスト用に結果を返す
+
+
+# ユニットテスト
+class TestTransactionBroadcaster(unittest.TestCase):
+    def setUp(self):
+        self.broadcaster = TransactionBroadcaster()
+
+    async def test_all_inputs_have_source_transaction(self):
+        # すべての入力にsource_transactionがある場合
+        inputs = [
+            Input(source_transaction="tx1"),
+            Input(source_transaction="tx2"),
+            Input(source_transaction="tx3")
+        ]
+        tx = Transaction(inputs=inputs)
+
+        result = await self.broadcaster.broadcast(tx)
+
+        # EFフォーマットが使われていることを確認
+        self.assertEqual(result["data"]["rawTx"], "ef_formatted_hex_data")
+
+    async def test_some_inputs_missing_source_transaction(self):
+        # 一部の入力にsource_transactionがない場合
+        inputs = [
+            Input(source_transaction="tx1"),
+            Input(source_transaction=None),  # source_transactionがない
+            Input(source_transaction="tx3")
+        ]
+        tx = Transaction(inputs=inputs)
+
+        result = await self.broadcaster.broadcast(tx)
+
+        # 通常のhexフォーマットが使われていることを確認
+        self.assertEqual(result["data"]["rawTx"], "normal_hex_data")
+
+    async def test_no_inputs_have_source_transaction(self):
+        # すべての入力にsource_transactionがない場合
+        inputs = [
+            Input(source_transaction=None),
+            Input(source_transaction=None),
+            Input(source_transaction=None)
+        ]
+        tx = Transaction(inputs=inputs)
+
+        result = await self.broadcaster.broadcast(tx)
+
+        # 通常のhexフォーマットが使われていることを確認
+        self.assertEqual(result["data"]["rawTx"], "normal_hex_data")
+
+
+# 非同期テストを実行するためのヘルパー関数
+import asyncio
+
+
+def run_async_test(test_case):
+    async_test = getattr(test_case, test_case._testMethodName)
+    asyncio.run(async_test())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description of Changes

Enable regular hex format broadcasting when source transactions are unavailable

Enhance the ARC broadcaster to dynamically select between EF and regular hex formats based on the availability of source transactions. This update addresses scenarios such as receiving raw hex via P2P payment destination Paymail capabilities.
Additionally, unit tests have been added to cover this feature.


## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ x] I have added new unit tests
- [x ] All tests pass locally
- [x ] I have tested manually in my local environment

## Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ x] I have run the linter